### PR TITLE
Update client

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ package mxplatformgo
 import (
 	"bytes"
 	"context"
-  "crypto/tls" // Required for MX custom tls
+	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime/multipart"
-  "net" // Required for MX custom tls
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -62,8 +62,7 @@ type service struct {
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
-    // Start MX custom tls
-    var netTransport = &http.Transport{
+		var netTransport = &http.Transport{
  			Dial: (&net.Dialer{
  				Timeout: 5 * time.Second,
  			}).Dial,
@@ -77,7 +76,6 @@ func NewAPIClient(cfg *Configuration) *APIClient {
  			Transport: netTransport,
  		}
  		cfg.HTTPClient = netClient
-    // End MX custom tls
 	}
 
 	c := &APIClient{}
@@ -206,12 +204,6 @@ func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }
 
-type formFile struct {
-		fileBytes []byte
-		fileName string
-		formFileName string
-}
-
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
@@ -220,7 +212,9 @@ func (c *APIClient) prepareRequest(
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
-	formFiles []formFile) (localVarRequest *http.Request, err error) {
+	formFileName string,
+	fileName string,
+	fileBytes []byte) (localVarRequest *http.Request, err error) {
 
 	var body *bytes.Buffer
 
@@ -239,7 +233,7 @@ func (c *APIClient) prepareRequest(
 	}
 
 	// add form parameters and file if available.
-	if strings.HasPrefix(headerParams["Content-Type"], "multipart/form-data") && len(formParams) > 0 || (len(formFiles) > 0) {
+	if strings.HasPrefix(headerParams["Content-Type"], "multipart/form-data") && len(formParams) > 0 || (len(fileBytes) > 0 && fileName != "") {
 		if body != nil {
 			return nil, errors.New("Cannot specify postBody and multipart form at the same time.")
 		}
@@ -258,17 +252,16 @@ func (c *APIClient) prepareRequest(
 				}
 			}
 		}
-		for _, formFile := range formFiles {
-			if len(formFile.fileBytes) > 0 && formFile.fileName != "" {
-				w.Boundary()
-				part, err := w.CreateFormFile(formFile.formFileName, filepath.Base(formFile.fileName))
-				if err != nil {
-						return nil, err
-				}
-				_, err = part.Write(formFile.fileBytes)
-				if err != nil {
-						return nil, err
-				}
+		if len(fileBytes) > 0 && fileName != "" {
+			w.Boundary()
+			//_, fileNm := filepath.Split(fileName)
+			part, err := w.CreateFormFile(formFileName, filepath.Base(fileName))
+			if err != nil {
+				return nil, err
+			}
+			_, err = part.Write(fileBytes)
+			if err != nil {
+				return nil, err
 			}
 		}
 
@@ -331,7 +324,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers[h] = []string{v}
+			headers.Set(h, v)
 		}
 		localVarRequest.Header = headers
 	}

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ package mxplatformgo
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
+	"crypto/tls" // Required for MX custom tls
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime/multipart"
-	"net"
+	"net" // Required for MX custom tls
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -62,6 +62,7 @@ type service struct {
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
+		// Start MX custom tls
 		var netTransport = &http.Transport{
  			Dial: (&net.Dialer{
  				Timeout: 5 * time.Second,
@@ -76,6 +77,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
  			Transport: netTransport,
  		}
  		cfg.HTTPClient = netClient
+		// End MX custom tls
 	}
 
 	c := &APIClient{}

--- a/configuration.go
+++ b/configuration.go
@@ -101,7 +101,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/0.1.1/go",
+		UserAgent:        "OpenAPI-Generator/0.1.2/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/openapi/config.yml
+++ b/openapi/config.yml
@@ -1,4 +1,4 @@
 gitRepoId: mx-platform-go
 gitUserId: mxenabled
 packageName: mxplatformgo
-packageVersion: 0.1.1
+packageVersion: 0.1.2

--- a/openapi/templates/client.mustache
+++ b/openapi/templates/client.mustache
@@ -4,7 +4,7 @@ package {{packageName}}
 import (
 	"bytes"
 	"context"
-  "crypto/tls" // Required for MX custom tls
+	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -13,7 +13,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime/multipart"
-  "net" // Required for MX custom tls
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -63,8 +63,7 @@ type service struct {
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
-    // Start MX custom tls
-    var netTransport = &http.Transport{
+		var netTransport = &http.Transport{
  			Dial: (&net.Dialer{
  				Timeout: 5 * time.Second,
  			}).Dial,
@@ -78,7 +77,6 @@ func NewAPIClient(cfg *Configuration) *APIClient {
  			Transport: netTransport,
  		}
  		cfg.HTTPClient = netClient
-    // End MX custom tls
 	}
 
 	c := &APIClient{}
@@ -213,12 +211,6 @@ func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }
 
-type formFile struct {
-		fileBytes []byte
-		fileName string
-		formFileName string
-}
-
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
@@ -227,7 +219,9 @@ func (c *APIClient) prepareRequest(
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
-	formFiles []formFile) (localVarRequest *http.Request, err error) {
+	formFileName string,
+	fileName string,
+	fileBytes []byte) (localVarRequest *http.Request, err error) {
 
 	var body *bytes.Buffer
 
@@ -246,7 +240,7 @@ func (c *APIClient) prepareRequest(
 	}
 
 	// add form parameters and file if available.
-	if strings.HasPrefix(headerParams["Content-Type"], "multipart/form-data") && len(formParams) > 0 || (len(formFiles) > 0) {
+	if strings.HasPrefix(headerParams["Content-Type"], "multipart/form-data") && len(formParams) > 0 || (len(fileBytes) > 0 && fileName != "") {
 		if body != nil {
 			return nil, errors.New("Cannot specify postBody and multipart form at the same time.")
 		}
@@ -265,17 +259,16 @@ func (c *APIClient) prepareRequest(
 				}
 			}
 		}
-		for _, formFile := range formFiles {
-			if len(formFile.fileBytes) > 0 && formFile.fileName != "" {
-				w.Boundary()
-				part, err := w.CreateFormFile(formFile.formFileName, filepath.Base(formFile.fileName))
-				if err != nil {
-						return nil, err
-				}
-				_, err = part.Write(formFile.fileBytes)
-				if err != nil {
-						return nil, err
-				}
+		if len(fileBytes) > 0 && fileName != "" {
+			w.Boundary()
+			//_, fileNm := filepath.Split(fileName)
+			part, err := w.CreateFormFile(formFileName, filepath.Base(fileName))
+			if err != nil {
+				return nil, err
+			}
+			_, err = part.Write(fileBytes)
+			if err != nil {
+				return nil, err
 			}
 		}
 
@@ -338,7 +331,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers[h] = []string{v}
+			headers.Set(h, v)
 		}
 		localVarRequest.Header = headers
 	}

--- a/openapi/templates/client.mustache
+++ b/openapi/templates/client.mustache
@@ -4,7 +4,7 @@ package {{packageName}}
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
+	"crypto/tls" // Required for MX custom tls
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -13,7 +13,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime/multipart"
-	"net"
+	"net" // Required for MX custom tls
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -63,6 +63,7 @@ type service struct {
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
+		// Start MX custom tls
 		var netTransport = &http.Transport{
  			Dial: (&net.Dialer{
  				Timeout: 5 * time.Second,
@@ -77,6 +78,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
  			Transport: netTransport,
  		}
  		cfg.HTTPClient = netClient
+		// End MX custom tls
 	}
 
 	c := &APIClient{}


### PR DESCRIPTION
The current client template was pulled from the `openapi-generator`'s
master branch, which is incorrect. This replaces the master template
with the correct `v5.3.0` template.