### PR TITLE
Bump version

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -101,7 +101,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader:    make(map[string]string),
-		UserAgent:        "OpenAPI-Generator/0.1.0/go",
+		UserAgent:        "OpenAPI-Generator/0.1.1/go",
 		Debug:            false,
 		Servers:          ServerConfigurations{
 			{

--- a/openapi/config.yml
+++ b/openapi/config.yml
@@ -1,4 +1,4 @@
 gitRepoId: mx-platform-go
 gitUserId: mxenabled
 packageName: mxplatformgo
-packageVersion: 0.1.0
+packageVersion: 0.1.1


### PR DESCRIPTION
A version bumped to `v0.1.1` was missed, this corrects that.