### PR TITLE
Simplify generate sdk workflow

### DIFF
--- a/.github/workflows/generate_sdk.yml
+++ b/.github/workflows/generate_sdk.yml
@@ -1,8 +1,8 @@
-name: Generate Publish Release
+name: Generate SDK
 
 on:
   repository_dispatch:
-    types: [generate_publish_release]
+    types: [generate_sdk]
 
 jobs:
   Generate:
@@ -25,7 +25,7 @@ jobs:
       - run: |
           openapi-generator-cli generate \
             -i https://raw.githubusercontent.com/mxenabled/openapi/master/openapi/mx_platform_api.yml \
-            -g go \
+            -g csharp-netcore \
             -c ./openapi/config.yml \
             -t ./openapi/templates
       - name: Checkout master
@@ -40,36 +40,6 @@ jobs:
           This commit was automatically created by a GitHub Action to generate version ${{ steps.bump_version.outputs.version }} of this library."
       - name: Push to master
         run: git push origin master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Slack notification
-        uses: ravsamhq/notify-slack-action@v2
-        if: always()
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: "{repo}: {workflow} workflow"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          footer: "<{workflow_url}|View Workflow>"
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  Release:
-    runs-on: ubuntu-latest
-    needs: Generate
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: 3.1
-      - name: Read version
-        id: read_version
-        run: echo "::set-output name=version::$(ruby .github/version.rb)"
-      - name: Create tag and release
-        run: |
-          gh release create "v${{ steps.read_version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Slack notification


### PR DESCRIPTION
Our `release` workflow runs when we `push` to `master` so we can remove the `release` job from our repository dispatch `generate_sdk` workflow.

This should also fix any issues we are seeing where we are trying to release using the wrong version. The old version seems to have been cached during the old flow which caused the workflow to fail.